### PR TITLE
Add typechecking with lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "npx eslint . --ext ts,tsx,js,jsx",
+    "lint": "eslint . --ext ts,tsx,js,jsx",
+    "typecheck": "tsc",
     "preview": "vite preview",
     "prepare": "husky install"
   },
@@ -32,6 +33,6 @@
     "vite": "^4.4.5"
   },
   "lint-staged": {
-    "*.{ts,tsx,js,jsx}": "npm run lint -- --fix"
+    "*.{ts,tsx}": ["bash -c 'npm run typecheck'", "npm run lint -- --fix"]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,6 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
+  "exclude": ["node_modules"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
This PR just cleans up the lint npm script and adds a new one for type checking, along with a corresponding `lint-staged` rule. This should block commits with type errors.

Resolve AD#14812