### PR TITLE
Install storybook a11y addon

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -7,6 +7,7 @@ const config: StorybookConfig = {
     "@storybook/addon-essentials",
     "@storybook/addon-onboarding",
     "@storybook/addon-interactions",
+    "@storybook/addon-a11y",
   ],
   framework: {
     name: "@storybook/react-vite",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
+        "@storybook/addon-a11y": "^7.4.1",
         "@storybook/addon-essentials": "^7.4.1",
         "@storybook/addon-interactions": "^7.4.1",
         "@storybook/addon-links": "^7.4.1",
@@ -3868,6 +3869,43 @@
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
     },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-7.4.1.tgz",
+      "integrity": "sha512-AYhf7xzOzFHUKsQ52riXfWc2H4pfMvHQFC6gOX0l6orfEek8bfsjNEM+VlZE1pKIOFvdj5EUzORPCtm/HoZkug==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addon-highlight": "7.4.1",
+        "@storybook/channels": "7.4.1",
+        "@storybook/client-logger": "7.4.1",
+        "@storybook/components": "7.4.1",
+        "@storybook/core-events": "7.4.1",
+        "@storybook/global": "^5.0.0",
+        "@storybook/manager-api": "7.4.1",
+        "@storybook/preview-api": "7.4.1",
+        "@storybook/theming": "7.4.1",
+        "@storybook/types": "7.4.1",
+        "axe-core": "^4.2.0",
+        "lodash": "^4.17.21",
+        "react-resize-detector": "^7.1.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@storybook/addon-actions": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-7.4.1.tgz",
@@ -6717,6 +6755,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.1.tgz",
+      "integrity": "sha512-9l850jDDPnKq48nbad8SiEelCv4OrUWrKab/cPj0GScVg6cb6NbCCt/Ulk26QEq5jP9NnGr04Bit1BHyV6r5CQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/babel-core": {
@@ -13389,6 +13436,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-resize-detector": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.1.2.tgz",
+      "integrity": "sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@storybook/addon-a11y": "^7.4.1",
     "@storybook/addon-essentials": "^7.4.1",
     "@storybook/addon-interactions": "^7.4.1",
     "@storybook/addon-links": "^7.4.1",


### PR DESCRIPTION
This PR installs Storybook [a11y addon](https://storybook.js.org/addons/@storybook/addon-a11y/). This adds tooling to view components with different forms of vision impairment and colorblindness, and adds a tab for reporting a11y violations and warnings.

<img width="1270" alt="image" src="https://github.com/NYCPlanning/ae-design-system/assets/9055367/51053402-92d1-4228-9f51-29ab3188ea54">
