### PR TITLE
Add typography tokens and text styles

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import type { Preview } from "@storybook/react";
-import { ChakraBaseProvider } from "@chakra-ui/react";
-import { theme } from "../src/theme";
+import { ThemeProvider } from "../src/ThemeProvider";
 
 const preview: Preview = {
   parameters: {
@@ -15,9 +14,9 @@ const preview: Preview = {
   },
   decorators: [
     (Story) => (
-      <ChakraBaseProvider theme={theme}>
+      <ThemeProvider>
         <Story />
-      </ChakraBaseProvider>
+      </ThemeProvider>
     ),
   ],
 };

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -1,0 +1,10 @@
+import { ChakraBaseProvider } from "@chakra-ui/react";
+import { theme } from "./theme";
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+export const ThemeProvider = ({ children }: ThemeProviderProps) => (
+  <ChakraBaseProvider theme={theme}>{children}</ChakraBaseProvider>
+);

--- a/src/stories/Typography.mdx
+++ b/src/stories/Typography.mdx
@@ -1,0 +1,76 @@
+import { Meta, Typeset } from '@storybook/blocks';
+import { tokens } from "../theme/tokens"
+import { ThemeProvider } from "../ThemeProvider"
+import { Text, HStack, VStack } from "@chakra-ui/react";
+import { theme } from "../theme";
+
+<Meta title="Tokens/Typography" />
+
+export const sampleText = 'The quick brown fox jumps over the lazy dog';
+
+# Typography
+
+## Font Family
+Our primary font family is `Helvetica Neue`. There are two font family tokens that both refer to this family: `body` and `heading`.
+
+## Font Sizes
+<ThemeProvider>
+  <VStack align="start">
+    <Text fontSize="sm">sm: {sampleText}</Text>
+    <Text fontSize="md">md: {sampleText}</Text>
+    <Text fontSize="lg">lg: {sampleText}</Text>
+    <Text fontSize="xl">xl: {sampleText}</Text>
+    <Text fontSize="2xl">2x: {sampleText}</Text>
+    <Text fontSize="3xl">3xl: {sampleText}</Text>
+    <Text fontSize="4xl">4xl: {sampleText}</Text>
+  </VStack>
+</ThemeProvider>
+
+## Font Weights
+<ThemeProvider>
+  <HStack>
+    <Text fontSize="3xl" fontWeight="bold">Bold</Text>
+    <Text fontSize="3xl" fontWeight="medium">Medium</Text>
+    <Text fontSize="3xl" fontWeight="regular">Regular</Text>
+    <Text fontSize="3xl" fontWeight="light">Light</Text>
+  </HStack>
+</ThemeProvider>
+
+## Line Height
+We have one token for line height: `regular`. This token is used for all text and will assign the line height to be 150% of the text's font size.
+
+## Text Styles
+
+Text styles refer to names for common combinations of values for these css properties:
+
+* Font family, weight, and size
+* Line height
+* Letter spacing
+* Text decoration (strikethrough and underline)
+* Text transform (uppercase, lowercase, and capitalization)
+
+They make it easy for developers to quickly apply all of these styles to a piece of text. For instance, this code:
+```
+<Text textStyle="body">Hello, world.</Text>
+```
+will assign the `body` text style to the text. `body` assigns these token values to the corresponding style properties:
+```
+body: {
+  font: "body",
+  fontSize: "md",
+  fontWeight: "regular",
+},
+```
+
+### Our Text Styles
+<ThemeProvider>
+  <VStack align="start">
+    <Text textStyle="emphasis">emphasis: {sampleText}</Text>
+    <Text textStyle="lead">lead: {sampleText}</Text>
+    <Text textStyle="large">large: {sampleText}</Text>
+    <Text textStyle="body">body: {sampleText}</Text>
+    <Text textStyle="micro">micro: {sampleText}</Text>
+  </VStack>
+</ThemeProvider>
+
+

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -3,6 +3,7 @@ import { tokens } from "./tokens";
 import { semanticTokens } from "./semantic-tokens";
 import { components } from "./components";
 import { styles } from "./styles";
+import { textStyles } from "./text-styles";
 
 const config: ThemeConfig = {
   cssVarPrefix: "dcp",
@@ -12,6 +13,7 @@ export const theme: ChakraTheme = {
   components,
   config,
   direction: "ltr",
+  textStyles,
   styles,
   semanticTokens,
   ...tokens,

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -2,6 +2,7 @@ import { ThemeConfig, ChakraTheme } from "@chakra-ui/react";
 import { tokens } from "./tokens";
 import { semanticTokens } from "./semantic-tokens";
 import { components } from "./components";
+import { styles } from "./styles";
 
 const config: ThemeConfig = {
   cssVarPrefix: "dcp",
@@ -11,7 +12,7 @@ export const theme: ChakraTheme = {
   components,
   config,
   direction: "ltr",
-  styles: {},
+  styles,
   semanticTokens,
   ...tokens,
 };

--- a/src/theme/styles.ts
+++ b/src/theme/styles.ts
@@ -1,0 +1,12 @@
+import { Styles } from "@chakra-ui/theme-tools";
+
+export const styles: Styles = {
+  global: {
+    body: {
+      fontFamily: "body",
+      color: "gray.600",
+      lineHeight: "base",
+      fontWeight: "regular",
+    },
+  },
+};

--- a/src/theme/styles.ts
+++ b/src/theme/styles.ts
@@ -5,7 +5,7 @@ export const styles: Styles = {
     body: {
       fontFamily: "body",
       color: "gray.600",
-      lineHeight: "base",
+      lineHeight: "regular",
       fontWeight: "regular",
     },
   },

--- a/src/theme/text-styles.ts
+++ b/src/theme/text-styles.ts
@@ -1,0 +1,29 @@
+import { SystemStyleObjectRecord } from "@chakra-ui/react";
+
+export const textStyles: SystemStyleObjectRecord = {
+  emphasis: {
+    font: "body",
+    fontSize: "3xl",
+    fontWeight: "light",
+  },
+  lead: {
+    font: "body",
+    fontSize: "xl",
+    fontWeight: "regular",
+  },
+  large: {
+    font: "body",
+    fontSize: "lg",
+    fontWeight: "regular",
+  },
+  body: {
+    font: "body",
+    fontSize: "md",
+    fontWeight: "regular",
+  },
+  micro: {
+    font: "body",
+    fontSize: "sm",
+    fontWeight: "regular",
+  },
+};

--- a/src/theme/tokens/font-sizes.ts
+++ b/src/theme/tokens/font-sizes.ts
@@ -1,1 +1,9 @@
-export const fontSizes = {};
+export const fontSizes = {
+  sm: "0.875rem",
+  md: "1rem",
+  lg: "1.25rem",
+  xl: "1.5rem",
+  "2xl": "1.75rem",
+  "3xl": "2rem",
+  "4xl": "2.25rem",
+};

--- a/src/theme/tokens/font-weights.ts
+++ b/src/theme/tokens/font-weights.ts
@@ -1,1 +1,6 @@
-export const fontWeights = {};
+export const fontWeights = {
+  bold: 700,
+  medium: 500,
+  regular: 400,
+  light: 300,
+};

--- a/src/theme/tokens/fonts.ts
+++ b/src/theme/tokens/fonts.ts
@@ -1,1 +1,4 @@
-export const fonts = {};
+export const fonts = {
+  heading: `Helvetica Neue, Arial, sans-serif`,
+  body: `Helvetica Neue, Arial, sans-serif`,
+};

--- a/src/theme/tokens/letter-spacing.ts
+++ b/src/theme/tokens/letter-spacing.ts
@@ -1,1 +1,9 @@
-export const letterSpacings = {};
+export const letterSpacings = {
+  sm: "0.875rem",
+  md: "1rem",
+  lg: "1.25rem",
+  xl: "1.5rem",
+  "2xl": "1.75rem",
+  "3xl": "2rem",
+  "4xl": "2.25rem",
+};

--- a/src/theme/tokens/letter-spacing.ts
+++ b/src/theme/tokens/letter-spacing.ts
@@ -1,9 +1,1 @@
-export const letterSpacings = {
-  sm: "0.875rem",
-  md: "1rem",
-  lg: "1.25rem",
-  xl: "1.5rem",
-  "2xl": "1.75rem",
-  "3xl": "2rem",
-  "4xl": "2.25rem",
-};
+export const letterSpacings = {};

--- a/src/theme/tokens/line-heights.ts
+++ b/src/theme/tokens/line-heights.ts
@@ -1,3 +1,3 @@
 export const lineHeights = {
-  base: 1.5,
+  regular: 1.5,
 };

--- a/src/theme/tokens/line-heights.ts
+++ b/src/theme/tokens/line-heights.ts
@@ -1,1 +1,3 @@
-export const lineHeights = {};
+export const lineHeights = {
+  base: 1.5,
+};


### PR DESCRIPTION
# Summary
This PR adds our tokens for token types concerning typography and some other associated changes. 
* Adds tokens for font size, weight, and family, as well as line height. 
* Adds a few of what Chakra calls [Text Styles](https://chakra-ui.com/docs/styled-system/text-and-layer-styles#text-styles). These are "shorthands" for certain combinations of typography token values. The ones I added came from Figma specs
* Adds a `Typography.mdx` page that documents these changes in Storybook:
<img width="1484" alt="image" src="https://github.com/NYCPlanning/ae-design-system/assets/9055367/86e1a32d-2f09-457b-a402-75245daba832">
* Adds a new `ThemeProvider` component that is just a convenience wrapper for `ChakraBaseProvder` with our theme passed in. This can eventually be used in applications build with our design system, but it's also helpful to have here, such as for wrapping tsx code in mdx stories so that they can include Chakra components
* Add `styles.ts` with some basic global stylings. The ones I added are meant to set "default" styles for text based on Figma specs.
