### PR TITLE
Prevent storybook styles from bleeding into mdx pages 

### DIFF
--- a/.storybook/ThemeBlock.tsx
+++ b/.storybook/ThemeBlock.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Unstyled } from "@storybook/blocks";
+import { ThemeProvider } from "../src/ThemeProvider";
+
+interface ThemeBlockProps {
+  children: React.ReactNode;
+}
+
+export const ThemeBlock = ({ children }: ThemeBlockProps) => (
+  <Unstyled>
+    <ThemeProvider>{children}</ThemeProvider>
+  </Unstyled>
+);

--- a/src/stories/Typography.mdx
+++ b/src/stories/Typography.mdx
@@ -1,6 +1,6 @@
-import { Meta, Typeset } from '@storybook/blocks';
+import { Meta, Unstyled } from '@storybook/blocks';
 import { tokens } from "../theme/tokens"
-import { ThemeProvider } from "../ThemeProvider"
+import { ThemeBlock } from "../../.storybook/ThemeBlock"
 import { Text, HStack, VStack } from "@chakra-ui/react";
 import { theme } from "../theme";
 
@@ -14,7 +14,7 @@ export const sampleText = 'The quick brown fox jumps over the lazy dog';
 Our primary font family is `Helvetica Neue`. There are two font family tokens that both refer to this family: `body` and `heading`.
 
 ## Font Sizes
-<ThemeProvider>
+<ThemeBlock>
   <VStack align="start">
     <Text fontSize="sm">sm: {sampleText}</Text>
     <Text fontSize="md">md: {sampleText}</Text>
@@ -24,17 +24,17 @@ Our primary font family is `Helvetica Neue`. There are two font family tokens th
     <Text fontSize="3xl">3xl: {sampleText}</Text>
     <Text fontSize="4xl">4xl: {sampleText}</Text>
   </VStack>
-</ThemeProvider>
+</ThemeBlock>
 
 ## Font Weights
-<ThemeProvider>
+<ThemeBlock>
   <HStack>
     <Text fontSize="3xl" fontWeight="bold">Bold</Text>
     <Text fontSize="3xl" fontWeight="medium">Medium</Text>
     <Text fontSize="3xl" fontWeight="regular">Regular</Text>
-    <Text fontSize="3xl" fontWeight="light">Light</Text>
+    <Text fontSize="3xl" fontWeight="light" fontFamily="body">Light</Text>
   </HStack>
-</ThemeProvider>
+</ThemeBlock>
 
 ## Line Height
 We have one token for line height: `regular`. This token is used for all text and will assign the line height to be 150% of the text's font size.
@@ -63,7 +63,7 @@ body: {
 ```
 
 ### Our Text Styles
-<ThemeProvider>
+<ThemeBlock>
   <VStack align="start">
     <Text textStyle="emphasis">emphasis: {sampleText}</Text>
     <Text textStyle="lead">lead: {sampleText}</Text>
@@ -71,6 +71,6 @@ body: {
     <Text textStyle="body">body: {sampleText}</Text>
     <Text textStyle="micro">micro: {sampleText}</Text>
   </VStack>
-</ThemeProvider>
+</ThemeBlock>
 
 

--- a/src/stories/Typography.mdx
+++ b/src/stories/Typography.mdx
@@ -56,7 +56,7 @@ They make it easy for developers to quickly apply all of these styles to a piece
 will assign the `body` text style to the text. `body` assigns these token values to the corresponding style properties:
 ```
 body: {
-  font: "body",
+  fontFamily: "body",
   fontSize: "md",
   fontWeight: "regular",
 },

--- a/src/theme/text-styles.ts
+++ b/src/theme/text-styles.ts
@@ -2,27 +2,27 @@ import { SystemStyleObjectRecord } from "@chakra-ui/react";
 
 export const textStyles: SystemStyleObjectRecord = {
   emphasis: {
-    font: "body",
+    fontFamily: "body",
     fontSize: "3xl",
     fontWeight: "light",
   },
   lead: {
-    font: "body",
+    fontFamily: "body",
     fontSize: "xl",
     fontWeight: "regular",
   },
   large: {
-    font: "body",
+    fontFamily: "body",
     fontSize: "lg",
     fontWeight: "regular",
   },
   body: {
-    font: "body",
+    fontFamily: "body",
     fontSize: "md",
     fontWeight: "regular",
   },
   micro: {
-    font: "body",
+    fontFamily: "body",
     fontSize: "sm",
     fontWeight: "regular",
   },


### PR DESCRIPTION
# Summary
This PR fixes two bugs both having to do with the typography tokens I recently added
* Fixed a typo in the text styles - replacing `font` with `fontFamily`
* Fixed a bug where the global styles in `styles.ts` weren't being reflected properly in `Typography.mdx`. Those styles were being overridden by Storybook's default styling for things like font family, size, and weight. Some digging led me to [this issue](https://github.com/storybookjs/storybook/issues/20600), which in turn led me to SB's `<Unstyled>` [storyblock](https://storybook.js.org/docs/react/api/doc-block-unstyled#page-top). I created a new utility DocBlock at `ThemeBlock.tsx` that takes `ThemeProvider` and wraps it in `<Unstyled>`. This should ensure anything wrapped in that will render free of any styles coming from Storybook itself.