### PR TITLE
Add Actions to run linting on PR opened

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,23 @@
+name: Pull Request
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout
+      - name: Setup node env
+        uses: actions/setup-node
+        with:
+          node-version: 18.17.1
+      - name: Install dependencies
+        run: npm ci
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Lint
+        run: npm run lint

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,9 +10,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout
+      - uses: actions/checkout@v4
       - name: Setup node env
-        uses: actions/setup-node
+        uses: actions/setup-node@v3
         with:
           node-version: 18.17.1
       - name: Install dependencies


### PR DESCRIPTION
This PR adds a basic GH action that triggers when a pull request is opened (or when an open one receives new commits) against `main`. The action runs the `lint` and `typecheck` npm scripts.